### PR TITLE
Add draft Read the Docs configuration and API docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,18 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: '3.11'
+  jobs:
+    pre_install:
+      - pip install --upgrade pip
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+    - method: pip
+      path: .
+    - requirements: docs/requirements.txt

--- a/README.md
+++ b/README.md
@@ -57,3 +57,13 @@ You may find our example notebooks in the `notebooks` folder.
 - Demo notebook for a single-cell Anndata object (demo)[https://github.com/sinanugur/easydecon/blob/main/notebooks/demo.ipynb]
 - Demo notebook for macrophage markers (demo_macrophage)[https://github.com/sinanugur/easydecon/blob/main/notebooks/demo_macrophage.ipynb]
 - Minimal example notebook (minimal)[https://github.com/sinanugur/easydecon/blob/main/notebooks/demo_minimal_example.ipynb]
+
+Read the Docs
+-------------
+A draft Sphinx configuration is included for hosting API documentation on Read
+the Docs. Build the site locally with:
+
+```bash
+pip install -r docs/requirements.txt
+sphinx-build -b html docs docs/_build/html
+```

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,50 @@
+API Reference
+=============
+
+The following sections expose the public Python API. Objects are grouped by
+module for clarity. The documentation uses ``autodoc`` to pull docstrings
+directly from the source code.
+
+.. contents::
+   :local:
+   :depth: 2
+
+Core Module
+-----------
+
+.. automodule:: easydecon.easydecon
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Segmentation Utilities
+----------------------
+
+.. automodule:: easydecon.segmentation
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Modelling Utilities
+-------------------
+
+.. automodule:: easydecon.modelling
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Extra Utilities
+---------------
+
+.. automodule:: easydecon.extra
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Configuration
+-------------
+
+.. automodule:: easydecon.config
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,43 @@
+import os
+import sys
+
+# Add project root to sys.path for autodoc
+sys.path.insert(0, os.path.abspath('..'))
+
+project = 'easydecon'
+author = 'Project contributors'
+release = '0.1.0'
+
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.autosummary',
+    'sphinx.ext.napoleon',
+    'sphinx.ext.viewcode',
+]
+
+templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+autosummary_generate = True
+autodoc_default_options = {
+    'members': True,
+    'undoc-members': True,
+    'show-inheritance': False,
+}
+
+# Mock optional dependencies to keep autodoc light-weight
+autodoc_mock_imports = [
+    'scanpy',
+    'fireducks',
+    'pandas',
+    'spatialdata',
+    'spatialdata_io',
+    'spatialdata_plot',
+    'numpy',
+    'scipy',
+    'tqdm',
+    'sklearn',
+]
+
+html_theme = 'sphinx_rtd_theme'
+html_static_path = ['_static']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,13 @@
+EasyDecon Documentation
+=======================
+
+Welcome to the draft documentation for ``easydecon``. This site is intended for
+hosting on Read the Docs and provides a concise overview of the project along
+with API references generated from the codebase.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents
+
+   usage
+   api

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+sphinx>=6.2.1
+sphinx-rtd-theme>=2.0.0

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,0 +1,35 @@
+Getting Started
+===============
+
+Installation
+------------
+
+Install ``easydecon`` from source to access the latest features::
+
+   git clone https://github.com/your-org/easydecon.git
+   cd easydecon
+   pip install -e .[dev]
+
+If you plan to build the documentation locally, install the optional docs
+requirements::
+
+   pip install -r docs/requirements.txt
+
+Quick Usage
+-----------
+
+Once installed, import the package to access the high-level utilities::
+
+   import easydecon
+   from easydecon.easydecon import common_markers_gene_expression_and_filter
+
+Refer to the :doc:`api` section for full details on the available modules and
+functions.
+
+Read the Docs Configuration
+---------------------------
+
+This repository includes a minimal ``.readthedocs.yaml`` configuration so the
+site can be built on `Read the Docs <https://readthedocs.org/>`_. The build uses
+Sphinx with the Read the Docs theme and mocks heavy scientific dependencies to
+keep API generation lightweight.


### PR DESCRIPTION
## Summary
- add a Read the Docs configuration and Sphinx setup for generating project documentation
- provide draft usage and API reference pages that autodocument the main modules
- note the documentation build steps in the README

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69244ce2dde4832ebb43406b0a472bf4)